### PR TITLE
Changed cafienne postgres to use a single database instance.

### DIFF
--- a/cafienne-postgres.yml
+++ b/cafienne-postgres.yml
@@ -42,40 +42,24 @@ services:
       - ./src/idp-conf/dex.yaml:/config.yaml
       - ./run/dex/:/var/dex/
 
-  cafienne-event-db:
+  cafienne-db:
     image: postgres:12.1-alpine
     networks:
       - dev
     expose:
       - 5432
     ports:
-      - "5431:5432"
-    hostname: cafienne-event-db
-    container_name: cafienne-event-db
+      - "5432:5432"
+    hostname: cafienne-db
+    container_name: cafienne-getting-started-db
     environment:
       POSTGRES_USER: postgresuser
       POSTGRES_PASSWORD: mysecret
       POSTGRES_DB: cafienne-eventstore
     volumes:
-      - postgres-event-db-data:/var/lib/postgresql/data
+      - cafienne-db-data:/var/lib/postgresql/data
+      - "./src/postgres-initdb:/docker-entrypoint-initdb.d"
            
-  cafienne-query-db:
-    image: postgres:12.1-alpine
-    networks:
-      - dev
-    expose:
-      - 5432
-    ports:
-      - "5430:5432"
-    hostname: cafienne-query-db
-    container_name: cafienne-query-db
-    environment:
-      POSTGRES_USER: postgresuser
-      POSTGRES_PASSWORD: mysecret
-      POSTGRES_DB: cafienne-query
-    volumes:
-      - postgres-query-db-data:/var/lib/postgresql/data
-
   cafienne-ide:
     image: cafienne/ide:latest
     labels: 
@@ -141,7 +125,7 @@ services:
       timeout: 10s
       retries: 5
     environment:
-      EVENT_DB_URL: ${EVENT_DB_URL:-jdbc:postgresql://cafienne-event-db:5432/cafienne-eventstore?reWriteBatchedInserts=true}    
+      EVENT_DB_URL: ${EVENT_DB_URL:-jdbc:postgresql://cafienne-db:5432/cafienne-eventstore?reWriteBatchedInserts=true}    
       EVENT_DB_PROFILE: ${EVENT_DB_PROFILE:-slick.jdbc.PostgresProfile$}
       EVENT_DB_DRIVER: ${EVENT_DB_DRIVER:-org.postgresql.Driver}
       EVENT_DB_USER: ${EVENT_DB_USER:-postgresuser}
@@ -150,7 +134,7 @@ services:
       PROJECTION_DB_DRIVER: ${PROJECTION_DB_DRIVER:-org.postgresql.Driver}
       PROJECTION_DB_USER: ${PROJECTION_DB_USER:-postgresuser}
       PROJECTION_DB_PASSWORD: ${PROJECTION_DB_PASSWORD:-mysecret}
-      PROJECTION_DB_URL: ${PROJECTION_DB_URL:-jdbc:postgresql://cafienne-query-db:5432/cafienne-query?reWriteBatchedInserts=true}
+      PROJECTION_DB_URL: ${PROJECTION_DB_URL:-jdbc:postgresql://cafienne-db:5432/cafienne-query?reWriteBatchedInserts=true}
     volumes:
       - ./run/cafienne/journal:/opt/cafienne/journal
       - ./run/cafienne/logs:/opt/cafienne/logs
@@ -158,15 +142,12 @@ services:
       - ./src/jdbc-conf:/opt/cafienne/conf
       - ./target/definitions:/opt/cafienne/definitions
     depends_on:
-      - cafienne-event-db
-      - cafienne-query-db
+      - cafienne-db
       - idp
       - mailcatcher
 
 volumes:
-  postgres-event-db-data:
-    driver: local
-  postgres-query-db-data:
+  cafienne-db-data:
     driver: local
   dex:
     driver: local

--- a/src/postgres-initdb/create_projectionsdb.sh
+++ b/src/postgres-initdb/create_projectionsdb.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE DATABASE "cafienne-query";
+    GRANT ALL PRIVILEGES ON DATABASE "cafienne-query" TO postgresuser;
+EOSQL


### PR DESCRIPTION
The postgres configuration spins up 2 postgres instances. 
That is not required when you add a create script for the query database to the first instance. 

In order to test, don't forget to remove the existing database volumes with `docker volume rm`